### PR TITLE
[python] feat: add keep_in_memory option in serialize_corpora

### DIFF
--- a/serialize_corpora.py
+++ b/serialize_corpora.py
@@ -63,6 +63,9 @@ class Arguments:
     load_from_cache_file: bool = field(
         default=True,
     )
+    keep_in_memory: bool = field(
+        default=False,
+    )
 
 
 def main():
@@ -79,6 +82,7 @@ def main():
         batch_size=args.batch_size,
         writer_batch_size=args.writer_batch_size,
         load_from_cache_file=args.load_from_cache_file,
+        keep_in_memory=args.keep_in_memory,
         remove_columns=corpora.column_names,
     )
 


### PR DESCRIPTION
- serialize에 keep_in_memory option 추가
- 이슈 #42 와 연결되어 map 도중에 cacha file 을 저장하지 않고 memory 에서 처리할 수 있는 option 추가