### PR TITLE
[docs] fix: Change a license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "lassl"
 version = "0.1.0"
 description = "Easy framework for pre-training language models"
 authors = ["seopbo <bsk0130@gmail.com>", "bzantium <ryumin93@gmail.com>", "iron-ij <yij1126@gmail.com>", "monologg <adieujw@gmail.com>"]
-license = "MIT"
+license = "Apache-2.0"
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
- Replace `MIT` with `Apache-2.0` in pyproject.toml

Refs: #61